### PR TITLE
Translate error messages, especially message regarding CORS issue

### DIFF
--- a/lang/en.js
+++ b/lang/en.js
@@ -1,4 +1,7 @@
 ﻿CKEDITOR.plugins.setLang('imagerotate', 'en', {
   rotateRight: 'Rotate Clockwise',
-  rotateLeft: 'Rotate Counter-clockwise'
+  rotateLeft: 'Rotate Counter-clockwise',
+  errorNoImage: "no image element?",
+  errorNoDOMImage: "no DOM image element?",
+  errorImageFromOtherDomain: "Image is from other domain and can't be rotated",
 });

--- a/lang/et.js
+++ b/lang/et.js
@@ -1,4 +1,7 @@
 ﻿CKEDITOR.plugins.setLang('imagerotate', 'et', {
   rotateRight: 'Pööra päripäeva',
-  rotateLeft: 'Pööra vastupäeva'
+  rotateLeft: 'Pööra vastupäeva',
+  errorNoImage: "no image element?",
+  errorNoDOMImage: "no DOM image element?",
+  errorImageFromOtherDomain: "Image is from other domain and can't be rotated",
 });

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,7 +1,7 @@
 CKEDITOR.plugins.setLang('imagerotate', 'fr', {
   rotateRight: 'Rotation horaire',
   rotateLeft: 'Rotation antihoraire',
-  errorNoImage: "no image element?",
-  errorNoDOMImage: "no DOM image element?",
-  errorImageFromOtherDomain: "Image is from other domain and can't be rotated",
+  errorNoImage: "Aucune image trouvée?",
+  errorNoDOMImage: "Aucune image trouvée dans le DOM?",
+  errorImageFromOtherDomain: "L'image provient d'un autre site (domaine) et ne peut pas être manipulée pour des raisons de sécurité",
 });

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,4 +1,7 @@
 CKEDITOR.plugins.setLang('imagerotate', 'fr', {
   rotateRight: 'Rotation horaire',
-  rotateLeft: 'Rotation antihoraire'
+  rotateLeft: 'Rotation antihoraire',
+  errorNoImage: "no image element?",
+  errorNoDOMImage: "no DOM image element?",
+  errorImageFromOtherDomain: "Image is from other domain and can't be rotated",
 });

--- a/plugin.js
+++ b/plugin.js
@@ -68,12 +68,12 @@
     var element = selection.getStartElement();
     var imageElement = element.getAscendant('img', true);
     if (!imageElement) {
-      editor.showNotification("no image element?", "warning");
+      editor.showNotification(editor.lang.imagerotate.errorNoImage, "warning");
       return;
     }
     var domImageElement = imageElement.$;
     if (!domImageElement) {
-      editor.showNotification("no DOM image element?", "warning");
+      editor.showNotification(editor.lang.imagerotate.errorNoDOMImage, "warning");
       return;
     }
 
@@ -86,7 +86,7 @@
       rotateByAngle(domImageElement, angle);
     } catch (err) {
       if (err.code === 18) {
-        editor.showNotification("Image is from other domain and can't be rotated", "warning");
+        editor.showNotification(editor.lang.imagerotate.errorImageFromOtherDomain, "warning");
       }
     }
   }


### PR DESCRIPTION
Hi @liias 

we finally had issues with CORS in Chrome for example so decided to translate the error message for the user.

As tested, "en" is the fall-back language so when plug-in used with another language it will work as well.

I added the messages to the "et" language but could not translate it...

Thank you!

Gauthier